### PR TITLE
Update includes/boilerplate-classes/options.php

### DIFF
--- a/includes/boilerplate-classes/options.php
+++ b/includes/boilerplate-classes/options.php
@@ -18,12 +18,12 @@ class Plugin_Boilerplate_Options_v_1 {
 	 * Stores parent class as static
 	 * @param class $parent (reference) the parent class
 	 */
-	function __construct( &$parent ) {
+	function __construct( $parent ) {
 
-		$this->parent = &$parent;
+		$this->parent = $parent;
 
-		add_action( 'admin_init', array( &$this, 'options_init' ) );
-		add_action( $this->parent->prefix . 'options', array( &$this, 'default_options_filter' ), 20 );
+		add_action( 'admin_init', array( $this, 'options_init' ) );
+		add_action( $this->parent->prefix . 'options', array( $this, 'default_options_filter' ), 20 );
 		
 	}
 
@@ -36,7 +36,7 @@ class Plugin_Boilerplate_Options_v_1 {
 		if ( empty( $this->parent->options->defaults ) )
 			return;
 
-		register_setting( $this->parent->slug_, $this->parent->slug_, array( &$this, 'validate' ) );
+		register_setting( $this->parent->slug_, $this->parent->slug_, array( $this, 'validate' ) );
 
 	}
 


### PR DESCRIPTION
For PHP 5.4.x compatibility changed all instances of: 

&$this to $this
&$parent to $parent
