### PR TITLE
Update includes/boilerplate-classes/debug.php

### DIFF
--- a/includes/boilerplate-classes/debug.php
+++ b/includes/boilerplate-classes/debug.php
@@ -16,11 +16,11 @@ class Plugin_Boilerplate_Debug_v_1 {
 	 * Register with WordPress API on construct
 	 * @param class $parent the parent class
 	 */
-	function __construct( &$parent ) {
+	function __construct( $parent ) {
 
-		$this->parent = &$parent;
+		$this->parent = $parent;
 
-		add_action( 'init', array( &$this, 'init' ), 5 );
+		add_action( 'init', array( $this, 'init' ), 5 );
 
 	}
 
@@ -33,8 +33,8 @@ class Plugin_Boilerplate_Debug_v_1 {
 		if ( !current_user_can( 'manage_options' ) || !WP_DEBUG )
 			return;
 
-		add_filter('debug_bar_panels', array( &$this, 'init_panel' ) );
-		add_filter('debug_bar_panels',  array( &$this, 'register_panel' ), 20 );
+		add_filter('debug_bar_panels', array( $this, 'init_panel' ) );
+		add_filter('debug_bar_panels',  array( $this, 'register_panel' ), 20 );
 
 	}
 
@@ -93,7 +93,7 @@ class Plugin_Boilerplate_Debug_v_1 {
 	function register_panel( $panels ) {
 		$slug = $this->parent->slug_;
 		$class = "{$slug}_Debug_Panel";
-		$panels[] = new $class( $this->parent->name . ' Debug', &$this );
+		$panels[] = new $class( $this->parent->name . ' Debug', $this );
 
 		return $panels;
 


### PR DESCRIPTION
For PHP 5.4.x compatibility changed all instances of: 

&$this to $this
&$parent to $parent
