### PR TITLE
Update includes/boilerplate-classes/cache.php

### DIFF
--- a/includes/boilerplate-classes/cache.php
+++ b/includes/boilerplate-classes/cache.php
@@ -14,9 +14,9 @@ class Plugin_Boilerplate_Cache_v_1 {
 	 * Stores parent class
 	 * @param class $parent the parent class
 	 */
-	function __construct( &$parent ) {
+	function __construct( $parent ) {
 
-		$this->parent = &$parent;
+		$this->parent = $parent;
 
 	}
 


### PR DESCRIPTION
For PHP 5.4.x compatibility changed all instances of: 

&$parent to $parent
