### PR TITLE
Fix bug in cron.php; `%n` is not a valid printf type specifier

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -18,4 +18,4 @@ if ( !$tmac )
 	
 $mentions = $tmac->mentions_check();
 
-printf( _n( '%n mention found', '%n mentions found', $mentions, 'twitter-mentions-as-comments' ), $mentions );
+printf( _n( '%d mention found', '%d mentions found', $mentions, 'twitter-mentions-as-comments' ), $mentions );


### PR DESCRIPTION
This bug results in the number of mentions being found (or not found) appearing as blank when running `cron.php`. For a list of valid type specifiers, see http://www.php.net/manual/en/function.sprintf.php.
